### PR TITLE
Add additional details to errors including key, value, and desired type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Gemfile.lock
 *.gem
 coverage
+tags
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/lib/safe_type.rb
+++ b/lib/safe_type.rb
@@ -12,12 +12,12 @@ require 'safe_type/primitive/time'
 
 module SafeType
   class << self
-    def coerce(input, rule)
-      return rule.coerce(input) if rule.is_a?(SafeType::Rule)
+    def coerce(input, rule, coerce_key=nil)
+      return rule.coerce(input, coerce_key) if rule.is_a?(SafeType::Rule)
       if rule.class == ::Hash
         result = {}
         rule.each do |key, val|
-          result[key] = coerce(input[key], val)
+          result[key] = coerce(input[key], val, key)
         end
         return result
       end
@@ -26,7 +26,7 @@ module SafeType
         result = ::Array.new(input.length)
         i = 0
         while i < input.length
-          result[i] = coerce(input[i], rule[i % rule.length])
+          result[i] = coerce(input[i], rule[i % rule.length], i)
           i += 1
         end
         return result
@@ -40,7 +40,7 @@ module SafeType
           if val.class == ::Hash
             coerce!(input[key], val)
           else
-            input[key] = coerce(input[key], val)
+            input[key] = coerce(input[key], val, key)
           end
         end
         return nil
@@ -48,7 +48,7 @@ module SafeType
       if rule.class == ::Array
         i = 0
         while i < input.length
-          input[i] = coerce(input[i], rule[i % rule.length])
+          input[i] = coerce(input[i], rule[i % rule.length], i)
           i += 1
         end
         return nil

--- a/lib/safe_type/errors.rb
+++ b/lib/safe_type/errors.rb
@@ -1,19 +1,17 @@
 module SafeType
-  class Error < StandardError; end
-
-  class CoercionError < Error
+  class CoercionError < StandardError
     def initialize(message="unable to transform into the requested type")
       super
     end
   end
 
-  class ValidationError < Error
+  class ValidationError < StandardError
     def initialize(message="failed to validate")
       super
     end
   end
 
-  class EmptyValueError < Error
+  class EmptyValueError < StandardError
     def initialize(message="the value should not be empty")
       super
     end

--- a/lib/safe_type/errors.rb
+++ b/lib/safe_type/errors.rb
@@ -1,25 +1,52 @@
 module SafeType
-  class CoercionError < StandardError
-    def initialize(message="unable to transform into the requested type")
-      super
+
+  class CoercionError < StandardError 
+    attr_reader :key
+    attr_reader :value
+    attr_reader :desired_type
+
+    def initialize(value, desired_type, key=nil)
+      super("Could not coerce " + (key.nil? ? '' : "key (#{key}) with ")  +
+            "value (#{value.inspect}) of type (#{value.class}) to desired type (#{desired_type})")
+
+      @key = key
+      @value = value
+      @desired_type = desired_type
     end
   end
 
   class ValidationError < StandardError
-    def initialize(message="failed to validate")
-      super
+    attr_reader :key
+    attr_reader :value
+    attr_reader :desired_type
+
+    def initialize(value, desired_type, key=nil)
+      super("Validation for " + (key.nil? ? '' : "key (#{key}) with ")  +
+            "value (#{value.inspect}) of " +
+            "type (#{value.class}) to desired type (#{desired_type}) has failed")
+
+      @key = key
+      @value = value
+      @desired_type = desired_type
     end
   end
 
   class EmptyValueError < StandardError
-    def initialize(message="the value should not be empty")
-      super
+    attr_reader :key
+    attr_reader :value
+
+    def initialize(desired_type, key=nil)
+      super("Expected a " + (key.nil? ? '' : "key (#{key}) with ")  +
+            "value of desired type (#{desired_type}), but received a nil value")
+
+      @key = key
+      @desired_type = desired_type
     end
   end
 
   class InvalidRuleError < ArgumentError
-    def initialize(message="invalid coercion rule")
-      super
+    def initialize()
+      super("Coercion rule does not exist or is not valid")
     end
   end
 end

--- a/lib/safe_type/errors.rb
+++ b/lib/safe_type/errors.rb
@@ -33,7 +33,7 @@ module SafeType
 
   class EmptyValueError < StandardError
     attr_reader :key
-    attr_reader :value
+    attr_reader :desired_type
 
     def initialize(desired_type, key=nil)
       super("Expected a " + (key.nil? ? '' : "key (#{key}) with ")  +

--- a/lib/safe_type/rule.rb
+++ b/lib/safe_type/rule.rb
@@ -24,10 +24,6 @@ module SafeType
       input
     end
 
-    def handle_exceptions(e)
-      raise SafeType::CoercionError
-    end
-
     def self.coerce(input)
       default.coerce(input)
     end
@@ -40,19 +36,19 @@ module SafeType
       new(required: true)
     end
 
-    def coerce(input)
-      raise SafeType::EmptyValueError if input.nil? && @required
+    def coerce(input, key=nil)
+      raise SafeType::EmptyValueError.new(@type, key) if input.nil? && @required
       input = before(input)
       input = Converter.to_type(input, @type)
-      raise SafeType::ValidationError unless is_valid?(input)
+      raise SafeType::ValidationError.new(input, @type, key) unless is_valid?(input)
       result = after(input)
-      raise SafeType::EmptyValueError if result.nil? && @required
+      raise SafeType::EmptyValueError.new(@type, key) if result.nil? && @required
       return @default if result.nil?
-      raise SafeType::CoercionError unless result.is_a?(@type)
+      raise SafeType::CoercionError.new(result, @type, key) unless result.is_a?(@type)
       result
-    rescue TypeError, ArgumentError, NoMethodError => e
+    rescue TypeError, ArgumentError, NoMethodError
       return @default if input.nil? && !@required
-      handle_exceptions(e)
+      raise SafeType::CoercionError.new(input, @type, key)
     end
   end
 end


### PR DESCRIPTION
- Pass object keys through to errors when available to provide a more descriptive error message
- Surface the input value and expected value in the error message to improve error description
- Create `attr_reader` fields to the errors to allow users to build custom errors