### PR TITLE
Fix coerce! bug. Do not modify unspecified fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,32 +70,69 @@ params["start_date"]      # => <Date: 2018-10-01 ((2458393j,0s,0n),+0s,2299161j)
 ## Ruby Hashes
 ```ruby
 json = {
-  "names" => ["Alice", "Bob", "Chris"],
+  "numbers" => [
+    ["10", "100", "1000"],
+    ["20", "200", "2000"],
+    ["30", "300", "3000"]
+  ],
   "info" => [
     {
       "type" => "dog",
-      "age" => "5",
+      "pets_age" => "45",
+      "num_of_siblings" => "3"
     },
     {
       "type" => "cat",
-      "age" => "4",
+      "pets_age" => "44",
+      "num_of_siblings" => "4"
     },
     {
       "type" => "fish",
-      "age" => "6",
+      "pets_age" => "46",
+      "num_of_siblings" => "5"
     }
   ]
 }
 
 SafeType::coerce!(json, {
-  "names" => [SafeType::String.strict],
+  "numbers" => [
+    [SafeType::Integer.strict, SafeType::String.strict],
+    [SafeType::Integer.strict],
+    [SafeType::String.strict]
+  ],
   "info" => [
     {
       "type" => SafeType::String.strict,
-      "age" => SafeType::Integer.strict
+      "pets_age" => SafeType::Integer.strict,
     }
   ]
 })
+
+# ANSWER
+answer = {
+  "numbers" => [
+    [10, "100", 1000],
+    [20, 200, 2000],
+    ["30", "300", "3000"]
+  ],
+  "info" => [
+    {
+      "type" => "dog",
+      "pets_age" => 45,
+      "num_of_siblings" => "3"
+    },
+    {
+      "type" => "cat",
+      "pets_age" => 44,
+      "num_of_siblings" => "4"
+    },
+    {
+      "type" => "fish",
+      "pets_age" => 46,
+      "num_of_siblings" => "5"
+    }
+  ]
+}
 ```
 ## Network Responses 
 ```ruby

--- a/lib/safe_type.rb
+++ b/lib/safe_type.rb
@@ -37,9 +37,11 @@ module SafeType
     def coerce!(input, rule)
       if rule.class == ::Hash
         rule.each do |key, val|
-          if val.class == ::Hash
+          # if element is a collection, coerce individually
+          if val.class == ::Hash || val.class == ::Array
             coerce!(input[key], val)
           else
+            # if not a collection, reassign simple object to coerced value
             input[key] = coerce(input[key], val, key)
           end
         end
@@ -48,7 +50,14 @@ module SafeType
       if rule.class == ::Array
         i = 0
         while i < input.length
-          input[i] = coerce(input[i], rule[i % rule.length], i)
+          val = rule[i % rule.length]
+          # if this is an array of collections (Array|Hash), coerce those collections individually
+          if val.class == ::Hash || val.class == ::Array
+            coerce!(input[i], val)
+          else
+            # if not a collection, reassign simple object in array to coerced value
+            input[i] = coerce(input[i], val)
+          end
           i += 1
         end
         return nil


### PR DESCRIPTION
Summary: Fixed bug that caused coerce! to not include properties that were not specified in nested hashes, or array of hashes.

Test Plan:
 - Run rspec suite: spec/safe_type_spec.rb
 - Test array of hashes, and not include properties in the hash. coerce using coerce! Ensure that the property remains in original input, unmodified/uncoerced.

Reviewers: hdoan, alexg

Differential Revision: https://openeducationlabs.phacility.com/D24624